### PR TITLE
Changes due to mypy-refactor from ITR

### DIFF
--- a/src/ITR_examples/ITR_DV.py
+++ b/src/ITR_examples/ITR_DV.py
@@ -52,7 +52,7 @@ from ITR.temperature_score import TemperatureScore
 from pint import Quantity
 from pint_pandas import PintType
 
-from .. import data_dir
+from . import data_dir
 
 # import base64
 
@@ -2085,7 +2085,7 @@ def update_graph(
     agg_temp_scores = [agg_score(i) for i in PortfolioAggregationMethod]
     methods, scores = list(map(list, zip(*agg_temp_scores)))
     if ITR.HAS_UNCERTAINTIES:
-        scores_n, scores_s = [
+        scores_n, scores_s = [  # type: ignore
             *map(
                 list,
                 zip(

--- a/src/ITR_examples/__init__.py
+++ b/src/ITR_examples/__init__.py
@@ -9,11 +9,11 @@ else:
 
 import pathlib
 
-data_dir = ""
+data_dir = pathlib.Path("")
 # import sysconfig
 # print(sysconfig.get_paths()["purelib"])
 
-if data_dir == "":
+if data_dir == pathlib.Path(""):
     data_dir = pathlib.Path(__file__).parent.parent / "data"
 else:
     # Validate data_dir

--- a/test/utils.py
+++ b/test/utils.py
@@ -4,12 +4,19 @@ import unittest
 
 import ITR
 import pandas as pd
-
-# from pint_pandas import PintType
 from ITR.data.osc_units import EI_Metric, EI_Quantity
-from ITR.interfaces import ICompanyData  # ICompanyEIProjections,
-from ITR.interfaces import EScope, ICompanyEIProjection, ICompanyEIProjectionsScopes
+from ITR.interfaces import (
+    EScope,
+    ICompanyData,
+    ICompanyEIProjection,
+    ICompanyEIProjections,
+    ICompanyEIProjectionsScopes,
+)
+
+# isort: split
+
 from pint import Quantity
+from pint_pandas import PintType
 
 
 class ITR_Encoder(json.JSONEncoder):
@@ -41,7 +48,7 @@ class DequantifyQuantity(json.JSONEncoder):
 
 
 def assert_pint_series_equal(
-    case: unittest.case,
+    case: unittest.case.TestCase,
     left: pd.Series,
     right: pd.Series,
     places=7,
@@ -72,7 +79,7 @@ def assert_pint_series_equal(
 
 
 def assert_pint_frame_equal(
-    case: unittest.case,
+    case: unittest.case.TestCase,
     left: pd.DataFrame,
     right: pd.DataFrame,
     places=7,


### PR DESCRIPTION
The new mypy refactor means that we should test whether or not things are `empty()` rather than testing if they are `None`.  Much better for type checking.

Make `port_numer` a variable we can set in a single place to make it easier to run multiple instances  of ITR_UI.py side-by-side.  (Helps with debugging against older versions).

Otherwise, fix up a few small problems found with mypy.

This works with the ITR library after merging https://github.com/os-climate/ITR/pull/302