### PR TITLE
Feat: Add separate/dedicated linting workflow

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -1,0 +1,37 @@
+---
+name: "⛔️ Standalone linting checks"
+
+# yamllint disable-line rule:truthy
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
+    branches:
+      - "*"
+      - "!update-devops-tooling"
+
+jobs:
+  linting:
+    # Don't run if pull request is NOT merged
+    # if: github.event.pull_request.merged == true
+    runs-on: "ubuntu-latest"
+
+    steps:
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.10
+
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+
+      - name: "Install linting tools"
+        run: pip install mypy
+
+      - name: "Linting with: mypy"
+        uses: sasanquaneuf/mypy-github-action@releases/v1
+        with:
+          checkName: 'linting'   # NOTE: needs to be the same as the job name
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
MyPy with type checking requires additional Python modules to be installed. Those modules are limited to 250MB in pre-commit.ci. The quantity of installs for ITR-examples exceeds this amount, therefore mypy linting needs to be moved to a separate/dedicated workflow triggered when code is submitted.