### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/workflows/notebooks.yaml
+++ b/.github/workflows/notebooks.yaml
@@ -9,44 +9,49 @@ on:
     types: [opened, reopened, edited, synchronize]
 
 jobs:
-  build:
-    name: "Build and test"
+
+  parse-project-metadata:
+    name: "Determine Python versions"
+    # yamllint disable-line rule:line-length
+    uses: os-climate/devops-reusable-workflows/.github/workflows/pyproject-toml-fetch-matrix.yaml@main
+
+  notebook-build:
+    name: "Build and test Notebooks"
+    needs: [parse-project-metadata]
     runs-on: ubuntu-latest
     continue-on-error: true
+    # Don't run when pull request is merged
+    if: github.event.pull_request.merged == false
+
     strategy:
       fail-fast: false
-      matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+      matrix: ${{ fromJson(needs.parse-project-metadata.outputs.matrix) }}
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v4
 
       - name: "Set up Python ${{ matrix.python-version }}"
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: "Setup PDM for build commands"
-        uses: pdm-project/setup-pdm@v3
+        uses: pdm-project/setup-pdm@v4
         with:
-          # Pinned to preserve Python3.9 functionality
-          version: 2.10.0
           python-version: ${{ matrix.python-version }}
 
       - name: "Install dependencies"
         run: |
-          which python
-          which python3
-          python --version
-          python3 --version
+          which python; which python3
+          python --version; python3 --version
           python -m pip install --upgrade pip
           pdm export -o requirements.txt
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           pip install .
           pip install pytest nbmake
 
-      - name: "Build notebooks: pytest"
-        run: pytest --nbmake notebooks/quick_temp_score_calculation.ipynb
+      - name: "Test notebooks: pytest --nbmake"
+        run: pytest --nbmake -- **/*ipynb
 
       - name: Upload logs as artefacts
         if: always()


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit