### PR TITLE
Chore: Update DevOps tooling from central repository [skip ci]

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,8 @@ on:
   push:
     # Only invoked on release tag pushes
     branches:
-      - '**'
+      - 'main'
+      - 'master'
     tags:
       - 'v*.*.*'
 

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -46,7 +46,7 @@ jobs:
           python -m pip install --upgrade pip
           pdm export -o requirements.txt
           pip install -r requirements.txt
-          pip install --upgrade pytest
+          pip install --upgrade pytest pytest-cov
           pip install .
 
       - name: "Run unit tests: pytest"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,6 @@ repos:
       - id: requirements-txt-fixer
       - id: trailing-whitespace
 
-  # Autoformat: YAML, JSON, Markdown, etc.
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v4.0.0-alpha.8
     hooks:
@@ -58,23 +57,11 @@ repos:
         args:
           ['--no-error-on-unmatched-pattern', '--ignore-unknown']
 
-  # Lint: Markdown
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.41.0
     hooks:
       - id: markdownlint
         args: ["--fix"]
-
-  # - repo: https://github.com/psf/black-pre-commit-mirror
-  #   rev: 24.4.2
-  #   hooks:
-  #     - id: black
-  #     - id: black-jupyter
-
-  # - repo: https://github.com/tomcatling/black-nb
-  #   rev: '0.7'
-  #   hooks:
-  #     - id: black-nb
 
   - repo: https://github.com/jorisroovers/gitlint
     rev: v0.19.1
@@ -98,12 +85,6 @@ repos:
       - id: pydocstyle
         additional_dependencies: ["tomli"]
 
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ["--profile", "black"]
-
   - repo: https://github.com/Mateusz-Grzelinski/actionlint-py
     rev: v1.7.0.14
     hooks:
@@ -122,14 +103,6 @@ repos:
       - id: yamllint
         args: [ "-d", "{rules: {line-length: {max: 120}}, ignore-from-file: [.gitignore],}", ]
 
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.10.0"
-    hooks:
-      - id: mypy
-        verbose: true
-        args: ["--show-error-codes", "--install-types", "--non-interactive"]
-        additional_dependencies: ["pytest", "types-requests"]
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.4.5
     hooks:
@@ -138,6 +111,14 @@ repos:
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
         files: ^(scripts|tests|custom_components)/.+\.py$
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: "v1.10.0"
+    hooks:
+      - id: mypy
+        verbose: true
+        args: ["--show-error-codes", "--install-types", "--non-interactive"]
+        additional_dependencies: ["pytest", "types-requests"]
 
   # Check for misspellings in documentation files
   # - repo: https://github.com/codespell-project/codespell


### PR DESCRIPTION
Update repository with content from upstream: os-climate/devops-toolkit